### PR TITLE
add signed user-agent (by default) for traceability

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,17 +1,22 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
 	"path"
 
+	flag "github.com/spf13/pflag"
 	"github.com/surface-security/scanner-go-entrypoint/scanner"
 )
+
+const DEFAULT_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36 github.com/surface-security/scanner-httpx"
 
 func main() {
 	s := scanner.Scanner{Name: "httpx"}
 	options := s.BuildOptions()
+	userAgent := flag.String("ua", DEFAULT_USER_AGENT, "Choose user-agent - use empty value for a random UA")
 	scanner.ParseOptions(options)
 
 	err := os.MkdirAll(options.Output, 0755)
@@ -26,11 +31,17 @@ func main() {
 	}
 	defer os.Remove(file.Name())
 
-	err = s.Exec(
+	args := []string{
 		"-silent", "-no-fallback", "-pipeline", "-tech-detect",
 		"-json", "-o", file.Name(),
 		"-l", options.Input,
-	)
+	}
+
+	if *userAgent != "" {
+		args = append(args, "-H", fmt.Sprintf("User-Agent: %s", *userAgent))
+	}
+
+	err = s.Exec(args...)
 	if err != nil {
 		log.Fatalf("Failed to run scanner: %v", err)
 	}


### PR DESCRIPTION
This default UA was hardcoded in our httpx fork but it should be set here instead.

httpx fork has it removed in https://github.com/surface-security/httpx/pull/35 and it is now added here